### PR TITLE
Fix typo and add ::install to include for php-ioncube

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,8 @@ default['app']['session_backend'] = "files"
 default['app']['session_backend_redis']['server'] = 'localhost'
 default['app']['session_backend_redis']['port'] = '6379'
 
+default['app']['fpc_backend'] = 'magento'
+
 default['app']['primary_user'] = "vagrant"
 default['app']['cron_user'] = "vagrant"
 default['app']['cron_mailto'] = "sysadmin@aligent.com.au"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@ default['app']['session_backend_redis']['port'] = '6379'
 
 default['app']['primary_user'] = "vagrant"
 default['app']['cron_user'] = "vagrant"
+default['app']['cron_mailto'] = "sysadmin@aligent.com.au"
 
 default['app']['vhost_cookbook'] = 'aligent-magento-dev'
 

--- a/recipes/aws-cache-flush.rb
+++ b/recipes/aws-cache-flush.rb
@@ -34,6 +34,6 @@ cookbook_file '/usr/local/bin/cache-flush.sh' do
   source 'cache-flush.sh'
   owner 'root'
   group 'root'
-  mode '0644'
+  mode '0755'
   action :create
 end

--- a/recipes/magento-cron.rb
+++ b/recipes/magento-cron.rb
@@ -30,7 +30,7 @@ if node['app']['runs_cron']
     action :create
     minute '*'
     user node['app']['cron_user']
-    mailto 'sysadmin@aligent.com.au'
+    mailto node['app']['cron_mailto']
     command "if [ -x #{node['app']['document_root']}/cron.sh ]; then #{node['app']['document_root']}/cron.sh; fi"
   end
 

--- a/templates/default/env.php.erb
+++ b/templates/default/env.php.erb
@@ -129,5 +129,15 @@ return array (
     ),
   ),
   <% end -%>
+  <% if node['app']['fpc_backend'] == 'varnish' -%>
+     'http_cache_hosts' =>
+  array (
+    0 =>
+    array (
+      'host' => "<%= node['app']['fpc_backend_varnish']['server'] %>",
+      'port' => "<%= node['app']['fpc_backend_varnish']['port'] %>",
+    ),
+  ),
+  <% end -%>
 );
 

--- a/templates/default/templates/process-template.sh.erb
+++ b/templates/default/templates/process-template.sh.erb
@@ -17,6 +17,8 @@ if [ -f $template ]; then
         -e "s/%ELASTICACHE_CACHE_PREFIX%/$ELASTICACHE_CACHE_PREFIX/" \
         -e "s/%ELASTICACHE_SESSION_SERVER%/$ELASTICACHE_SESSION_SERVER/" \
         -e "s/%ELASTICACHE_SESSION_PORT%/$ELASTICACHE_SESSION_PORT/" \
+        -e "s/%VARNISH_CACHE_SERVER%/$VARNISH_CACHE_SERVER/" \
+        -e "s/%VARNISH_CACHE_PORT%/$VARNISH_CACHE_PORT/" \
         < $template > $target
 fi
 


### PR DESCRIPTION
Missed a 'd' in enabled flag, and contrary to the documentation, the php-ioncube cookbook does not install by default, so I added '::install' to the include line to force it to work.
