### PR TITLE
Fix mysql-server.rb to not break mysql 5.5

### DIFF
--- a/recipes/mysql-server.rb
+++ b/recipes/mysql-server.rb
@@ -35,11 +35,13 @@ if node['app']['database_engine'] == 'mysql' || node['app']['database_engine'] =
         action [:create, :start]
     end
 
-    mysql_config 'default' do
-        source 'mysql_config.erb'
-        notifies :restart, 'mysql_service[default]'
-        action :create
-    end
+    if node['mysql']['server_version'] != "5.5"
+        mysql_config 'default' do
+            source 'mysql_config.erb'
+            notifies :restart, 'mysql_service[default]'
+            action :create
+        end
+    end 
 else
     include_recipe 'mariadb::server'
 end


### PR DESCRIPTION
Add conditional to the mysql-server recipe to work around a problem with mysql 5.5 which doesn't allow changes to the  innodb log file size after the log file is created.

This fix removes all tweaks for the local mysql server, but a better solution may
be to shut down the mysql server, remove the logfiles and restart the service.