### PR TITLE
Make Opcache settings completely configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,11 @@ default['app']['opcache']['enabled'] = true
 default['app']['opcache']['max_accelerated_files'] = 20000
 default['app']['opcache']['validate_timestamps'] = 0
 default['app']['opcache']['revalidate_freq'] = 60
+default['app']['opcache']['memory_consumption'] = 64
+default['app']['opcache']['interned_strings_buffer'] = 4
+default['app']['opcache']['fast_shutdown'] = 0
+default['app']['opcache']['load_comments'] = 1
+default['app']['opcache']['save_comments'] = 1
 
 default['app']['php']['memory_limit'] = '1024M'
 

--- a/recipes/php.rb
+++ b/recipes/php.rb
@@ -42,7 +42,7 @@ end
 
 
 template "/etc/php.d/zz-#{node['app']['name']}.ini" do
-  source "zz-magento.ini.erb"
+  source "zz-appname.ini.erb"
   mode '0644'
   owner 'root'
   group 'root'

--- a/templates/default/zz-appname.ini.erb
+++ b/templates/default/zz-appname.ini.erb
@@ -8,9 +8,11 @@ max_input_vars=20000
 <% if node['app']['opcache']['installed'] %>
     <% if node['app']['opcache']['enabled'] %>
 opcache.enable=1
-opcache.max_accelerated_files=<%= node['app']['opcache']['max_accelerated_files'] %>
-opcache.validate_timestamps=<%= node['app']['opcache']['validate_timestamps'] %>
-opcache.opcache.revalidate_freq=<%= node['app']['opcache']['revalidate_freq'] %>
+        <% node['app']['opcache'].each do |key, value| %>
+            <% if key != 'installed' && key != 'enabled' %>
+opcache.<%= key %>=<%= value %>
+            <% end %>
+        <% end %>
     <% else %>
 opcache.enable=0
     <% end %>


### PR DESCRIPTION
This should be safe, since the defaults for all new parameters are the PHP default.  So for existing builds there should be no nett change.  For new builds opcache can be customised in new ways.