### PR TITLE
Bump upstream mysql cookbook version to obtain 'mysqld_options' parameter

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,11 +6,11 @@ description      'Custom recipes for an Aligent dev environment'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.1'
 
-depends 'mysql2_chef_gem', '~> 1.0.2'
+depends 'mysql2_chef_gem', '~> 1.1.0'
 depends 'database', '~> 4.0.6'
 depends 'nginx', '~> 2.7.6'
 depends 'php', '~> 1.8.0'
-depends 'mysql', '~> 6.0.30'
+depends 'mysql', '~> 6.1.0'
 depends 'redis2', '~> 0.5.1'
 depends 's3_file', '~> 2.7.0'
 depends 'varnish', '~> 3.3.0'

--- a/recipes/mysql-server.rb
+++ b/recipes/mysql-server.rb
@@ -33,6 +33,9 @@ if node['app']['database_engine'] == 'mysql' || node['app']['database_engine'] =
         data_dir '/var/lib/mysql'
         initial_root_password node['mysql']['server_root_password']
         action [:create, :start]
+        mysqld_options = {
+                "innodb_log_file_size" => "100M",
+        }
     end
 
     mysql_config 'default' do


### PR DESCRIPTION
The mysql-cookbook recipe creates a mysql_server resource to install,
supply initial configuration, then starts the service.  The recipe then
deploys our custom configuration, then restarts the service again to pick
up the change; this causes mysql to fail to start due to a mismatch in the
innodb log file size created by the initial start (5MB) and the custom
config (100MB).

The new cookbook version permits injecting custom mysqld configuration
before the initial startup so that the pre-created log files match our intended
final configuration.