### PR TITLE
Permit cf-stack-environment.sh.erb to be sourced from another cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,8 @@ default['varnish']['configure']['vcl_template']['variables']['config']['backend_
 
 default['app']['ioncube']['enabled'] = false
 
+default['app']['cf_stack_environment_sh_cookbook'] = 'aligent-magento-dev'
+
 default["redis2"]["instances"]["cache"]["port"] = default['app']['cache_backend_redis']['port']
 default["redis2"]["instances"]["cache"]["appendonly"] = "no"
 default["redis2"]["instances"]["cache"]["appendfsync"] = "everysec"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@aligent.com.au'
 license          'MIT'
 description      'Custom recipes for an Aligent dev environment'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 depends 'mysql2_chef_gem', '~> 1.1.0'
 depends 'database', '~> 4.0.6'

--- a/recipes/aws-prompt-vagrant.rb
+++ b/recipes/aws-prompt-vagrant.rb
@@ -28,6 +28,7 @@
 
 template '/etc/profile.d/cf-stack-environment.sh' do
   source "cf-stack-environment.sh.erb"
+  cookbook node['app']['cf_stack_environment_sh_cookbook']
   mode 0644
   owner 'root'
   group 'root'


### PR DESCRIPTION
Default behaviour is unchanged; this allows for extra envvars to be be made available to scripts if required.