### PR TITLE
logrotate: permit controlling rotation interval and number of rotations

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,6 +74,8 @@ default["redis2"]["instances"]["session"]["appendonly"] = "yes"
 default["redis2"]["instances"]["session"]["appendfsync"] = "everysec"
 default["redis2"]["instances"]["session"]["bgsave"] = false
 
+default['logrotate']['interval'] = 'weekly'
+
 default['cwlogs']['region'] = 'ap-southeast-2'
 default['cwlogs']['state_file_dir'] = '/var/awslogs/state'
 default['cwlogs']['state_file_name'] = 'agent-state'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@aligent.com.au'
 license          'MIT'
 description      'Custom recipes for an Aligent dev environment'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.2.2'
 
 depends 'mysql2_chef_gem', '~> 1.1.0'
 depends 'database', '~> 4.0.6'

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -1,5 +1,8 @@
 <%= node['app']['document_root'] %>/var/log/*log {
-    weekly
+    <%= node['logrotate']['interval'] %>
+<%- if node['logrotate'].key?('magento_rotations') -%>
+    rotate <%= node['logrotate']['magento_rotations'] %>
+<%- end -%>
     missingok
     notifempty
     sharedscripts


### PR DESCRIPTION
Default to weekly with no count override, to maintain previous behaviour.