### PR TITLE
Install zip/unzip to avoid the memory leak issue.

### DIFF
--- a/recipes/codedeploy-agent.rb
+++ b/recipes/codedeploy-agent.rb
@@ -25,7 +25,7 @@
 ##
 #
 
-%w{wget ruby}.each do |pkg|
+%w{wget ruby zip unzip}.each do |pkg|
   package pkg do
     action :install
   end


### PR DESCRIPTION
CoopersDIY and Spendless have been experiencing CodeDeploy agent not returning memory after each deployment. 

Comment from https://github.com/aws/aws-codedeploy-agent/releases/tag/v1.1.2:
Memory efficiency improvements for Linux and Ubuntu to release reserved memory more timely. Unzip command will first attempt to use a system installed unzip utility before using rubyzip